### PR TITLE
Update for ES 6.0

### DIFF
--- a/examples/AmazonElasticsearchServiceSample.java
+++ b/examples/AmazonElasticsearchServiceSample.java
@@ -55,6 +55,7 @@ public class AmazonElasticsearchServiceSample extends Sample {
         String payload = "{\"test\": \"val\"}";
         HttpPost httpPost = new HttpPost(AES_ENDPOINT + "/index_name/type_name/document_id");
         httpPost.setEntity(stringEntity(payload));
+        httpPost.addHeader("Content-Type", "application/json");
         logRequest("es", httpPost);
     }
 }


### PR DESCRIPTION
ES 6.0 requires you to explicitly specify the header. Otherwise, it rejects the request with 406 Not Acceptable.

See https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests and https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking_60_rest_changes.html#_content_type_auto_detection.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.