### PR TITLE
Adds high-level REST client example

### DIFF
--- a/examples/AmazonElasticsearchServiceSample.java
+++ b/examples/AmazonElasticsearchServiceSample.java
@@ -16,26 +16,35 @@ import org.apache.http.client.methods.HttpPost;
 import java.io.IOException;
 
 /**
- * An AWS request signing interceptor sample for arbitrary HttpRequests to an Amazon Elasticsearch Service.
- * <p>
- * The interceptor can also be used e.g. with the Elasticsearch REST for additional convenience and serialization.
- * <p>
- * Example usage with Elasticsearch REST client:
- * <p>
+ * <p>An AWS Request Signing Interceptor sample for arbitrary HTTP requests to an Amazon Elasticsearch Service domain.</p>
+ * <p>The interceptor can also be used with the Elasticsearch REST clients for additional convenience and serialization.</p>
+ * <p>Example usage with the Elasticsearch low-level REST client:</p>
  * <pre>
- *
  * String serviceName = "es";
  * AWS4Signer signer = new AWS4Signer();
  * signer.setServiceName(serviceName);
  * signer.setRegionName("us-east-1");
  *
  * HttpRequestInterceptor interceptor =
- *      new AWSRequestSigningApacheInterceptor(serviceName, signer, credentialsProvider);
+ *     new AWSRequestSigningApacheInterceptor(serviceName, signer, credentialsProvider);
  *
  * return RestClient
- * .builder(HttpHost.create("https://search-my-es-endpoint-gjhfgfhgfhg.us-east-1.amazonaws.com"))
- * .setHttpClientConfigCallback(hacb -> hacb.addInterceptorLast(interceptor))
+ *     .builder(HttpHost.create("https://search-my-es-endpoint-gjhfgfhgfhg.us-east-1.amazonaws.com"))
+ *     .setHttpClientConfigCallback(hacb -> hacb.addInterceptorLast(interceptor))
  * .build();
+ * </pre>
+ * <p>Example usage with the Elasticsearch high-level REST client:</p>
+ * <pre>
+ * String serviceName = "es";
+ * AWS4Signer signer = new AWS4Signer();
+ * signer.setServiceName(serviceName);
+ * signer.setRegionName(region);
+ *
+ * HttpRequestInterceptor interceptor =
+ *     new AWSRequestSigningApacheInterceptor(serviceName, signer, credentialsProvider);
+ * return new RestHighLevelClient(RestClient
+ *     .builder(HttpHost.create("https://search-my-es-endpoint-gjhfgfhgfhg.us-east-1.amazonaws.com"))
+ *     .setHttpClientConfigCallback(hacb -> hacb.addInterceptorLast(interceptor)));
  * </pre>
  */
 public class AmazonElasticsearchServiceSample extends Sample {

--- a/examples/AmazonElasticsearchServiceSample.java
+++ b/examples/AmazonElasticsearchServiceSample.java
@@ -42,6 +42,7 @@ import java.io.IOException;
  *
  * HttpRequestInterceptor interceptor =
  *     new AWSRequestSigningApacheInterceptor(serviceName, signer, credentialsProvider);
+ * 
  * return new RestHighLevelClient(RestClient
  *     .builder(HttpHost.create("https://search-my-es-endpoint-gjhfgfhgfhg.us-east-1.amazonaws.com"))
  *     .setHttpClientConfigCallback(hacb -> hacb.addInterceptorLast(interceptor)));

--- a/examples/AmazonElasticsearchServiceSample.java
+++ b/examples/AmazonElasticsearchServiceSample.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * return RestClient
  *     .builder(HttpHost.create("https://search-my-es-endpoint-gjhfgfhgfhg.us-east-1.amazonaws.com"))
  *     .setHttpClientConfigCallback(hacb -> hacb.addInterceptorLast(interceptor))
- * .build();
+ *     .build();
  * </pre>
  * <p>Example usage with the Elasticsearch high-level REST client:</p>
  * <pre>

--- a/examples/AmazonElasticsearchServiceSample.java
+++ b/examples/AmazonElasticsearchServiceSample.java
@@ -38,7 +38,7 @@ import java.io.IOException;
  * String serviceName = "es";
  * AWS4Signer signer = new AWS4Signer();
  * signer.setServiceName(serviceName);
- * signer.setRegionName(region);
+ * signer.setRegionName("us-east-1");
  *
  * HttpRequestInterceptor interceptor =
  *     new AWSRequestSigningApacheInterceptor(serviceName, signer, credentialsProvider);


### PR DESCRIPTION
Also cleans up HTML and some of the language.

In my testing, building the client with the interceptor is slightly different depending on whether you use the [high-](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-high.html) or [low-level](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/java-rest-low.html) REST client.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.