### PR TITLE
Do not drop content-type/content-encoding headers from http entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+.idea/

--- a/src/main/java/com/amazonaws/http/AWSRequestSigningApacheInterceptor.java
+++ b/src/main/java/com/amazonaws/http/AWSRequestSigningApacheInterceptor.java
@@ -18,6 +18,7 @@ import com.amazonaws.auth.Signer;
 import org.apache.http.Header;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpException;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
@@ -59,14 +60,13 @@ public class AWSRequestSigningApacheInterceptor implements HttpRequestIntercepto
     private final AWSCredentialsProvider awsCredentialsProvider;
 
     /**
-     *
-     * @param service service that we're connecting to
-     * @param signer particular signer implementation
+     * @param service                service that we're connecting to
+     * @param signer                 particular signer implementation
      * @param awsCredentialsProvider source of AWS credentials for signing
      */
     public AWSRequestSigningApacheInterceptor(final String service,
-                                final Signer signer,
-                                final AWSCredentialsProvider awsCredentialsProvider) {
+                                              final Signer signer,
+                                              final AWSCredentialsProvider awsCredentialsProvider) {
         this.service = service;
         this.signer = signer;
         this.awsCredentialsProvider = awsCredentialsProvider;
@@ -82,7 +82,7 @@ public class AWSRequestSigningApacheInterceptor implements HttpRequestIntercepto
         try {
             uriBuilder = new URIBuilder(request.getRequestLine().getUri());
         } catch (URISyntaxException e) {
-            throw new IOException("Invalid URI" , e);
+            throw new IOException("Invalid URI", e);
         }
 
         // Copy Apache HttpRequest to AWS DefaultRequest
@@ -98,7 +98,7 @@ public class AWSRequestSigningApacheInterceptor implements HttpRequestIntercepto
         try {
             signableRequest.setResourcePath(uriBuilder.build().getRawPath());
         } catch (URISyntaxException e) {
-            throw new IOException("Invalid URI" , e);
+            throw new IOException("Invalid URI", e);
         }
 
         if (request instanceof HttpEntityEnclosingRequest) {
@@ -111,24 +111,34 @@ public class AWSRequestSigningApacheInterceptor implements HttpRequestIntercepto
         signableRequest.setParameters(nvpToMapParams(uriBuilder.getQueryParams()));
         signableRequest.setHeaders(headerArrayToMap(request.getAllHeaders()));
 
+        SignableRequestContentChangeInterceptor<?> wrappedSignableRequest =
+                new SignableRequestContentChangeInterceptor<>(signableRequest);
+
         // Sign it
-        signer.sign(signableRequest, awsCredentialsProvider.getCredentials());
+        signer.sign(wrappedSignableRequest, awsCredentialsProvider.getCredentials());
 
         // Now copy everything back
         request.setHeaders(mapToHeaderArray(signableRequest.getHeaders()));
-        if (request instanceof HttpEntityEnclosingRequest) {
+        // Replace http entity only if content got changed
+        if (wrappedSignableRequest.isContentChanged() &&
+                request instanceof HttpEntityEnclosingRequest) {
             HttpEntityEnclosingRequest httpEntityEnclosingRequest =
                     (HttpEntityEnclosingRequest) request;
             if (httpEntityEnclosingRequest.getEntity() != null) {
                 BasicHttpEntity basicHttpEntity = new BasicHttpEntity();
                 basicHttpEntity.setContent(signableRequest.getContent());
+                if (request.getFirstHeader(HttpHeaders.CONTENT_TYPE) != null) {
+                    basicHttpEntity.setContentType(request.getFirstHeader(HttpHeaders.CONTENT_TYPE));
+                }
+                if (request.getFirstHeader(HttpHeaders.CONTENT_ENCODING) != null) {
+                    basicHttpEntity.setContentEncoding(request.getFirstHeader(HttpHeaders.CONTENT_ENCODING));
+                }
                 httpEntityEnclosingRequest.setEntity(basicHttpEntity);
             }
         }
     }
 
     /**
-     *
      * @param params list of HTTP query params as NameValuePairs
      * @return a multimap of HTTP query params
      */

--- a/src/main/java/com/amazonaws/http/SignableRequestContentChangeInterceptor.java
+++ b/src/main/java/com/amazonaws/http/SignableRequestContentChangeInterceptor.java
@@ -1,0 +1,93 @@
+package com.amazonaws.http;
+
+import com.amazonaws.ReadLimitInfo;
+import com.amazonaws.SignableRequest;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Wrapper for SignableRequest which intercepts if the request content is changed.
+ *
+ * @param <T>
+ */
+public class SignableRequestContentChangeInterceptor<T> implements SignableRequest<T> {
+    private final SignableRequest<T> original;
+    private boolean contentChanged = false;
+
+    public SignableRequestContentChangeInterceptor(final SignableRequest<T> original) {
+        this.original = original;
+    }
+
+    @Override
+    public void addHeader(final String name, final String value) {
+        original.addHeader(name, value);
+    }
+
+    @Override
+    public void addParameter(final String name, final String value) {
+        original.addParameter(name, value);
+    }
+
+    @Override
+    public void setContent(final InputStream inputStream) {
+        original.setContent(inputStream);
+        contentChanged = true;
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        return original.getHeaders();
+    }
+
+    @Override
+    public String getResourcePath() {
+        return original.getResourcePath();
+    }
+
+    @Override
+    public Map<String, List<String>> getParameters() {
+        return original.getParameters();
+    }
+
+    @Override
+    public URI getEndpoint() {
+        return original.getEndpoint();
+    }
+
+    @Override
+    public HttpMethodName getHttpMethod() {
+        return original.getHttpMethod();
+    }
+
+    @Override
+    public int getTimeOffset() {
+        return original.getTimeOffset();
+    }
+
+    @Override
+    public InputStream getContent() {
+        return original.getContent();
+    }
+
+    @Override
+    public InputStream getContentUnwrapped() {
+        return original.getContentUnwrapped();
+    }
+
+    @Override
+    public ReadLimitInfo getReadLimitInfo() {
+        return original.getReadLimitInfo();
+    }
+
+    @Override
+    public Object getOriginalRequestObject() {
+        return original.getOriginalRequestObject();
+    }
+
+    public boolean isContentChanged() {
+        return contentChanged;
+    }
+}

--- a/src/test/java/com/amazonaws/http/AWSRequestSigningApacheInterceptorTest.java
+++ b/src/test/java/com/amazonaws/http/AWSRequestSigningApacheInterceptorTest.java
@@ -18,9 +18,13 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.AnonymousAWSCredentials;
 import com.amazonaws.auth.Signer;
+import com.amazonaws.util.IOUtils;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHttpEntityEnclosingRequest;
 import org.apache.http.message.BasicHttpRequest;
@@ -28,20 +32,23 @@ import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpCoreContext;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 public class AWSRequestSigningApacheInterceptorTest {
 
-    private static AWSRequestSigningApacheInterceptor createInterceptor() {
+    private static AWSRequestSigningApacheInterceptor createInterceptor(Signer signer) {
         AWSCredentialsProvider anonymousCredentialsProvider =
                 new AWSStaticCredentialsProvider(new AnonymousAWSCredentials());
         return new AWSRequestSigningApacheInterceptor("servicename",
-                new AddHeaderSigner("Signature", "wuzzle"),
+                signer,
                 anonymousCredentialsProvider);
-
     }
 
     @Test
@@ -55,7 +62,8 @@ public class AWSRequestSigningApacheInterceptorTest {
         HttpCoreContext context = new HttpCoreContext();
         context.setTargetHost(HttpHost.create("localhost"));
 
-        createInterceptor().process(request, context);
+        createInterceptor(new AddHeaderSigner("Signature", "wuzzle"))
+                .process(request, context);
 
         assertEquals("bar", request.getFirstHeader("foo").getValue());
         assertEquals("wuzzle", request.getFirstHeader("Signature").getValue());
@@ -64,9 +72,76 @@ public class AWSRequestSigningApacheInterceptorTest {
 
     @Test(expected = IOException.class)
     public void testBadRequest() throws Exception {
-
         HttpRequest badRequest = new BasicHttpRequest("GET", "?#!@*%");
-        createInterceptor().process(badRequest, new BasicHttpContext());
+        createInterceptor(new AddHeaderSigner("Signature", "wuzzle"))
+                .process(badRequest, new BasicHttpContext());
+    }
+
+    @Test
+    public void testHttpEntityIsCorrect() throws Exception {
+        HttpEntityEnclosingRequest request =
+                new BasicHttpEntityEnclosingRequest("GET", "/query?a=b");
+        BasicHttpEntity httpEntity = new BasicHttpEntity();
+        InputStream content = new ByteArrayInputStream(new byte[]{0, 1});
+        httpEntity.setContent(content);
+        httpEntity.setContentEncoding("gzip");
+        request.setEntity(httpEntity);
+
+        HttpCoreContext context = new HttpCoreContext();
+        context.setTargetHost(HttpHost.create("localhost"));
+
+        createInterceptor(new AddHeaderSigner("Signature", "wuzzle"))
+                .process(request, context);
+
+        assertNotNull(request.getEntity());
+        assertNotNull(request.getEntity().getContentEncoding());
+        assertEquals("gzip", request.getEntity().getContentEncoding().getValue());
+        assertEquals(content, request.getEntity().getContent());
+    }
+
+    @Test
+    public void testReplaceContentSigner() throws Exception {
+        HttpEntityEnclosingRequest request =
+                new BasicHttpEntityEnclosingRequest("GET", "/query?a=b");
+        ByteArrayEntity byteArrayEntity = new ByteArrayEntity("I'm an entity".getBytes(),
+                ContentType.TEXT_PLAIN);
+        request.setEntity(byteArrayEntity);
+        request.addHeader("foo", "bar");
+        request.addHeader("content-length", "0");
+        request.addHeader(byteArrayEntity.getContentType());
+
+        HttpCoreContext context = new HttpCoreContext();
+        context.setTargetHost(HttpHost.create("localhost"));
+
+        createInterceptor(new ReplaceContentSigner("new content"))
+                .process(request, context);
+        assertNotNull(request.getEntity().getContentType());
+        assertEquals(ContentType.TEXT_PLAIN.toString(),
+                request.getEntity().getContentType().getValue());
+        assertArrayEquals("new content".getBytes(),
+                IOUtils.toByteArray(request.getEntity().getContent()));
+    }
+
+    @Test
+    public void testEncodedUriSigner() throws Exception {
+        HttpEntityEnclosingRequest request =
+                new BasicHttpEntityEnclosingRequest("GET",
+                        "/foo-2017-02-25%2Cfoo-2017-02-26/_search?a=b");
+        request.setEntity(new StringEntity("I'm an entity"));
+        request.addHeader("foo", "bar");
+        request.addHeader("content-length", "0");
+
+        HttpCoreContext context = new HttpCoreContext();
+        context.setTargetHost(HttpHost.create("localhost"));
+
+        createInterceptor(new AddHeaderSigner("Signature", "wuzzle"))
+                .process(request, context);
+
+        assertEquals("bar", request.getFirstHeader("foo").getValue());
+        assertEquals("wuzzle", request.getFirstHeader("Signature").getValue());
+        assertNull(request.getFirstHeader("content-length"));
+        assertEquals("/foo-2017-02-25%2Cfoo-2017-02-26/_search",
+                request.getFirstHeader("resourcePath").getValue());
     }
 
     private static class AddHeaderSigner implements Signer {
@@ -78,7 +153,6 @@ public class AWSRequestSigningApacheInterceptorTest {
             this.value = value;
         }
 
-
         @Override
         public void sign(SignableRequest<?> request, AWSCredentials credentials) {
             request.addHeader(name, value);
@@ -86,23 +160,16 @@ public class AWSRequestSigningApacheInterceptorTest {
         }
     }
 
-    @Test
-    public void testEncodedUriSigner() throws Exception {
-        HttpEntityEnclosingRequest request =
-                new BasicHttpEntityEnclosingRequest("GET", "/foo-2017-02-25%2Cfoo-2017-02-26/_search?a=b");
-        request.setEntity(new StringEntity("I'm an entity"));
-        request.addHeader("foo", "bar");
-        request.addHeader("content-length", "0");
+    private static class ReplaceContentSigner implements Signer {
+        private final String content;
 
-        HttpCoreContext context = new HttpCoreContext();
-        context.setTargetHost(HttpHost.create("localhost"));
+        public ReplaceContentSigner(final String content) {
+            this.content = content;
+        }
 
-        createInterceptor().process(request, context);
-
-        assertEquals("bar", request.getFirstHeader("foo").getValue());
-        assertEquals("wuzzle", request.getFirstHeader("Signature").getValue());
-        assertNull(request.getFirstHeader("content-length"));
-        assertEquals("/foo-2017-02-25%2Cfoo-2017-02-26/_search", request.getFirstHeader("resourcePath").getValue());
+        @Override
+        public void sign(SignableRequest<?> request, AWSCredentials credentials) {
+            request.setContent(new ByteArrayInputStream(content.getBytes()));
+        }
     }
-
 }

--- a/src/test/java/com/amazonaws/http/SignableRequestContentChangeInterceptorTest.java
+++ b/src/test/java/com/amazonaws/http/SignableRequestContentChangeInterceptorTest.java
@@ -1,0 +1,21 @@
+package com.amazonaws.http;
+
+import com.amazonaws.DefaultRequest;
+import com.amazonaws.SignableRequest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+
+public class SignableRequestContentChangeInterceptorTest {
+    @Test
+    public void testContentChangeDetected() {
+        SignableRequest<?> signableRequest = new DefaultRequest<>("test-service");
+        signableRequest.setContent(new ByteArrayInputStream(new byte[]{0, 1}));
+        SignableRequestContentChangeInterceptor<?> wrapped =
+                new SignableRequestContentChangeInterceptor<>(signableRequest);
+        Assert.assertFalse(wrapped.isContentChanged());
+        wrapped.setContent(new ByteArrayInputStream(new byte[]{1, 2}));
+        Assert.assertTrue(wrapped.isContentChanged());
+    }
+}


### PR DESCRIPTION
Fixed missing 'content-type'/'content-encoding' headers in case of retries.

AWSRequestSigningApacheInterceptor incorrectly replaces HttpEnity during request signature. Basically, it does not copy content-encoding/content-type headers from HttpEnity. As a result if a retry is happening those headers are lost.

Full chain of events:
- http request with attached http entity is built, httpentity#contentEncoding and httpentity#contentType are set;
- RetryExec caches headers from original http request (https://github.com/apache/httpcomponents-client/blob/4.5.x/httpclient/src/main/java/org/apache/http/impl/execchain/RetryExec.java#L86);
- HttpClient request interceptor populates request headers from http entity (https://github.com/apache/httpcomponents-core/blob/4.4.x/httpcore/src/main/java/org/apache/http/protocol/RequestContent.java#L117);
- AWSRequestSigningApacheInterceptor signs the request and replaces existing http entity with a new one (https://github.com/awslabs/aws-request-signing-apache-interceptor/blob/master/src/main/java/com/amazonaws/http/AWSRequestSigningApacheInterceptor.java#L125), contentType/contentEncoding headers are not set for the new http entity;
- Retriable IO Exception is thrown,
- RetryExec resets http headers with original ones (https://github.com/apache/httpcomponents-client/blob/4.5.x/httpclient/src/main/java/org/apache/http/impl/execchain/RetryExec.java#L111);
- HttpClient request interceptor tries to populate headers from http entity, but http entity does not have contentType/contentEncoding headers set, so the request does not have contentType/contentEncoding headers;
- AWSRequestSigningApacheInterceptor signs the request (without contentType/contentEncoding headers);
- The request is sent (without contentType/contentEncoding headers);

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
