### PR TITLE
handle empty request entity

### DIFF
--- a/src/main/java/com/amazonaws/http/AWSRequestSigningApacheInterceptor.java
+++ b/src/main/java/com/amazonaws/http/AWSRequestSigningApacheInterceptor.java
@@ -104,7 +104,9 @@ public class AWSRequestSigningApacheInterceptor implements HttpRequestIntercepto
         if (request instanceof HttpEntityEnclosingRequest) {
             HttpEntityEnclosingRequest httpEntityEnclosingRequest =
                     (HttpEntityEnclosingRequest) request;
-            if (httpEntityEnclosingRequest.getEntity() != null) {
+            if (httpEntityEnclosingRequest.getEntity() == null) {
+                signableRequest.setContent(new ByteArrayInputStream(new byte[0]));
+            } else {
                 signableRequest.setContent(httpEntityEnclosingRequest.getEntity().getContent());
             }
         }

--- a/src/main/java/com/amazonaws/http/AWSRequestSigningApacheInterceptor.java
+++ b/src/main/java/com/amazonaws/http/AWSRequestSigningApacheInterceptor.java
@@ -27,6 +27,7 @@ import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.protocol.HttpContext;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
POST requests with a null request body do not get signed properly. This is a fix.

This issue comes up when executing Elasticsearch functions like ForceMerge.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
